### PR TITLE
Allocate pid arrays from the stack

### DIFF
--- a/unhide-linux-bruteforce.c
+++ b/unhide-linux-bruteforce.c
@@ -64,13 +64,19 @@ void *funcionThread (void *parametro)
 void brute(void) 
 {
    int i=0;
-   int allpids[maxpid] ;
-   int allpids2[maxpid] ;
+   int* allpids;
+   int* allpids2;
    int x;
    int y;
    int z;
 
    msgln(unlog, 0, "[*]Starting scanning using brute force against PIDS with fork()\n") ;
+
+   allpids = malloc(sizeof(int)*maxpid) ;
+   allpids2 = malloc(sizeof(int)*maxpid) ;
+   if (!allpids || !allpids2) {
+      die(unlog, "Error: Cannot allocate pid arrays ! Exiting.");
+   }
 
    // PID under 301 are reserved for kernel
    for(x=0; x < 301; x++) 
@@ -214,4 +220,7 @@ void brute(void)
          }
       }
    }
+
+   free(allpids);
+   free(allpids2);
 }


### PR DESCRIPTION
This patch was written and sent to Debian Project by Bernhard Übelacker.
It fix a segmentation fault see https://bugs.debian.org/945864 for details.

Author: Bernhard Übelacker <bernhardu@mailbox.org>
Bug-Debian: https://bugs.debian.org/945864
Last-Update: 2019-12-03

Fixed in Debian revision 20130526-4.