### PR TITLE
+ACTION: Edit+ fix a null pointer bug when failed to get maxpid

### DIFF
--- a/unhide-linux.c
+++ b/unhide-linux.c
@@ -112,7 +112,9 @@ void get_max_pid(int* newmaxpid)
    {
       *newmaxpid = tmppid;
    }
-   fclose(fd) ;
+   if (fd) {
+       fclose(fd);
+   }
 }
 
 /*


### PR DESCRIPTION
I fixed a null pointer error, added null pointer check on fclose of get_max_pid()

This fix make program more strong of protected SegFault when fd is NULL